### PR TITLE
Add a shortcut to switch cats and use modes' names in config

### DIFF
--- a/include/cats.hpp
+++ b/include/cats.hpp
@@ -13,6 +13,16 @@
 namespace cats
 {
 
+enum class CatModeId
+{
+    osu,
+    taiko,
+    ctb,
+    mania,
+    custom,
+    classic
+};
+
 class ICat : public sf::Drawable
 {
 public:
@@ -173,6 +183,6 @@ private:
     std::list<sf::Keyboard::Key> pressed_keys;
 };
 
-std::unique_ptr<ICat> get_cat(int mode);
+std::unique_ptr<ICat> get_cat(cats::CatModeId mode);
 
 }

--- a/share/config.json
+++ b/share/config.json
@@ -1,5 +1,5 @@
 {
-    "mode": 1,
+    "mode": "osu",
     "window": {
         "size": [612, 352],
         "offset": [0, 0],

--- a/src/cats.cpp
+++ b/src/cats.cpp
@@ -3,23 +3,22 @@
 namespace cats
 {
 
-std::unique_ptr<ICat> get_cat(int mode)
+std::unique_ptr<ICat> get_cat(cats::CatModeId mode)
 {
     switch (mode) {
-    case 1:
+    case CatModeId::osu:
         return std::make_unique<OsuCat>();
-    case 2:
+    case CatModeId::taiko:
         return std::make_unique<TaikoCat>();
-    case 3:
+    case CatModeId::ctb:
         return std::make_unique<CtbCat>();
-    case 4:
+    case CatModeId::mania:
         return std::make_unique<ManiaCat>();
-    case 5:
+    case CatModeId::custom:
         return std::make_unique<CustomCat>();
-    case 6:
+    case CatModeId::classic:
         return std::make_unique<ClassicCat>();
     default:
-        data::error_msg("Mode value is not correct", "Error reading configs");
         return nullptr;
     }
 }


### PR DESCRIPTION
- Cat modes can now be switched by Ctrl+N shortcut
- In config file: set a cat mode by its name instead of the mode number